### PR TITLE
Add initial support of UID and GID

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,10 +1,15 @@
 FROM python:3.6-slim as BUILDER
 
+WORKDIR /tmp
+
 # FROM python:3.7-slim AS compile-image
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential gcc wget git
 
-ENV PATH=/root/.local/bin:$PATH
+RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+USER avd
+
+ENV PATH=$PATH:/home/avd/.local/bin
 RUN pip3 install --upgrade pip
 RUN wget --quiet https://raw.githubusercontent.com/aristanetworks/ansible-avd/devel/development/requirements.txt
 RUN pip3 install --user  -r requirements.txt
@@ -25,6 +30,7 @@ LABEL com.example.version.is-production="False"
 ARG TERM=xterm
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV PROJECT_DIR /projects/
 
 # Install dependencies.
 RUN apt-get update \
@@ -43,26 +49,26 @@ RUN apt-get update \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
-COPY --from=BUILDER /root/.local/ /root/.local
-COPY entrypoint.sh /bin/entrypoint.sh
-RUN chmod +x /bin/entrypoint.sh
-
-# Create the /project directory and add it as a mountpoint
-
 RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
 USER avd
+
+# Copy python collection
+COPY --from=BUILDER /home/avd/.local/ /home/avd/.local
+ENV PATH=$PATH:/home/avd/.local/bin
 
 # Install Oh My ZSH to provide improved shell
 RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
     && echo 'plugins=(ansible common-aliases safe-paste git jsontools history git-extras)' >> $HOME/.zshrc \
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
-    && echo 'export TERM=xterm' >>  $HOME/.zshrc
+    && echo 'export TERM=xterm' >>  $HOME/.zshrc \
+    && echo 'export PATH=$PATH:/home/avd/.local/bin' >> $HOME/.zshrc
 
 # Set default folder
 WORKDIR /projects
 VOLUME ["/projects"]
 
 # Use ZSH as default shell with default oh-my-zsh theme
-ENV PATH=$PATH:/root/.local/bin
 USER root
+COPY entrypoint.sh /bin/entrypoint.sh
+RUN chmod +x /bin/entrypoint.sh
 CMD [ "/bin/entrypoint.sh" ]

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -48,8 +48,9 @@ COPY entrypoint.sh /bin/entrypoint.sh
 RUN chmod +x /bin/entrypoint.sh
 
 # Create the /project directory and add it as a mountpoint
-WORKDIR /projects
-VOLUME ["/projects"]
+
+RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+USER avd
 
 # Install Oh My ZSH to provide improved shell
 RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
@@ -57,6 +58,11 @@ RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/inst
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
     && echo 'export TERM=xterm' >>  $HOME/.zshrc
 
+# Set default folder
+WORKDIR /projects
+VOLUME ["/projects"]
+
 # Use ZSH as default shell with default oh-my-zsh theme
 ENV PATH=$PATH:/root/.local/bin
+USER root
 CMD [ "/bin/entrypoint.sh" ]

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -45,11 +45,17 @@ RUN apt-get update \
     sshpass \
     git-extras \
     openssh-client \
+    sudo \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
+RUN curl -fsSL https://get.docker.com | sh
 RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+RUN usermod -aG docker avd\
+    && usermod -aG sudo avd \
+    && echo "avd ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
 USER avd
 
 # Copy python collection
@@ -61,6 +67,10 @@ RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/inst
     && echo 'plugins=(ansible common-aliases safe-paste git jsontools history git-extras)' >> $HOME/.zshrc \
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
     && echo 'export TERM=xterm' >>  $HOME/.zshrc \
+    && echo "export LC_ALL=C.UTF-8" >> $HOME/.zshrc \
+    && echo "export LANG=C.UTF-8" >> $HOME/.zshrc \
+    && echo "export LC_ALL=C.UTF-8" >> $HOME/.zshrc \
+    && echo "export LANG=C.UTF-8" >> $HOME/.zshrc \
     && echo 'export PATH=$PATH:/home/avd/.local/bin' >> $HOME/.zshrc
 
 # Set default folder

--- a/3.6/entrypoint.sh
+++ b/3.6/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 # Install specific requirement file
 if [ ! -z "${AVD_REQUIREMENTS}" ]; then
   if [ -f ${AVD_REQUIREMENTS} ]; then
@@ -16,4 +17,15 @@ if [ ! -z "${AVD_ANSIBLE}" ]; then
     pip3 install --user ansible==${AVD_ANSIBLE}
 fi
 
-exec /bin/zsh
+# Reconfigure AVD User id if set by user
+if [ ! -z "${AVD_UID}" ]; then
+  echo "Update uid for user avd with ${AVD_UID}"
+  usermod -u ${AVD_UID} avd
+fi
+
+if [ ! -z "${AVD_GID}" ]; then
+  echo "Update gid for group avd with ${AVD_GID}"
+  groupmod -g ${AVD_GID} avd
+fi
+
+su - avd -c /bin/zsh

--- a/3.6/entrypoint.sh
+++ b/3.6/entrypoint.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+DOCKER_SOCKET=/var/run/docker.sock
+DOCKER_GROUP=docker
+USER=avd
 
 # Install specific requirement file
 if [ ! -z "${AVD_REQUIREMENTS}" ]; then
   if [ -f ${AVD_REQUIREMENTS} ]; then
     echo "Install new requirements from ${AVD_REQUIREMENTS}"
-    pip3 install --user -r ${AVD_REQUIREMENTS}
+    sudo -H -u ${USER} pip3 install --upgrade --user -r ${AVD_REQUIREMENTS}
   else
     echo "Requirement file not found, skipping..."
   fi
@@ -14,7 +17,9 @@ fi
 # Install specific ANSIBLE version
 if [ ! -z "${AVD_ANSIBLE}" ]; then
     echo "Install ansible with version ${AVD_ANSIBLE}"
-    pip3 install --user ansible==${AVD_ANSIBLE}
+    # Required for migration from 2.9 to 2.10
+    sudo -H -u ${USER} pip3 uninstall -y ansible
+    sudo -H -u ${USER} pip3 install --upgrade --user ansible==${AVD_ANSIBLE}
 fi
 
 # Reconfigure AVD User id if set by user
@@ -28,6 +33,12 @@ if [ ! -z "${AVD_GID}" ]; then
   groupmod -g ${AVD_GID} avd
 fi
 
+if [ -S ${DOCKER_SOCKET} ]; then
+    sudo chmod 666 /var/run/docker.sock &>/dev/null
+fi
+
 export PATH=$PATH:/home/avd/.local/bin
+export LC_ALL=C.UTF-8
+
 cd /projects/
 su - avd -c "cd /projects && /bin/zsh"

--- a/3.6/entrypoint.sh
+++ b/3.6/entrypoint.sh
@@ -28,4 +28,6 @@ if [ ! -z "${AVD_GID}" ]; then
   groupmod -g ${AVD_GID} avd
 fi
 
-su - avd -c /bin/zsh
+export PATH=$PATH:/home/avd/.local/bin
+cd /projects/
+su - avd -c "cd /projects && /bin/zsh"

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -53,20 +53,21 @@ RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
 USER avd
 
 # Copy python collection
-COPY --from=BUILDER /root/.local/ /home/avd/.local
+COPY --from=BUILDER /home/avd/.local/ /home/avd/.local
+ENV PATH=$PATH:/home/avd/.local/bin
 
 # Install Oh My ZSH to provide improved shell
 RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
     && echo 'plugins=(ansible common-aliases safe-paste git jsontools history git-extras)' >> $HOME/.zshrc \
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
-    && echo 'export TERM=xterm' >>  $HOME/.zshrc
+    && echo 'export TERM=xterm' >>  $HOME/.zshrc \
+    && echo 'export PATH=$PATH:/home/avd/.local/bin' >> $HOME/.zshrc
 
 # Set default folder
 WORKDIR /projects
 VOLUME ["/projects"]
 
 # Use ZSH as default shell with default oh-my-zsh theme
-ENV PATH=$PATH:/home/avd/.local/bin
 USER root
 COPY entrypoint.sh /bin/entrypoint.sh
 RUN chmod +x /bin/entrypoint.sh

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -49,7 +49,12 @@ RUN apt-get update \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
+RUN curl -fsSL https://get.docker.com | sh
 RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+RUN usermod -aG docker avd\
+    && usermod -aG sudo avd \
+    && echo "avd ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
 USER avd
 
 # Copy python collection
@@ -61,6 +66,8 @@ RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/inst
     && echo 'plugins=(ansible common-aliases safe-paste git jsontools history git-extras)' >> $HOME/.zshrc \
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
     && echo 'export TERM=xterm' >>  $HOME/.zshrc \
+    && echo "export LC_ALL=C.UTF-8" >> $HOME/.zshrc \
+    && echo "export LANG=C.UTF-8" >> $HOME/.zshrc \
     && echo 'export PATH=$PATH:/home/avd/.local/bin' >> $HOME/.zshrc
 
 # Set default folder

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -1,10 +1,15 @@
 FROM python:3.7-slim as BUILDER
 
+WORKDIR /tmp
+
 # FROM python:3.7-slim AS compile-image
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential gcc wget git
 
-ENV PATH=/root/.local/bin:$PATH
+RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+USER avd
+
+ENV PATH=$PATH:/home/avd/.local/bin
 RUN pip3 install --upgrade pip
 RUN wget --quiet https://raw.githubusercontent.com/aristanetworks/ansible-avd/devel/development/requirements.txt
 RUN pip3 install --user  -r requirements.txt
@@ -25,6 +30,7 @@ LABEL com.example.version.is-production="False"
 ARG TERM=xterm
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV PROJECT_DIR /projects/
 
 # Install dependencies.
 RUN apt-get update \
@@ -43,13 +49,11 @@ RUN apt-get update \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
-COPY --from=BUILDER /root/.local/ /root/.local
-COPY entrypoint.sh /bin/entrypoint.sh
-RUN chmod +x /bin/entrypoint.sh
+RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+USER avd
 
-# Create the /project directory and add it as a mountpoint
-WORKDIR /projects
-VOLUME ["/projects"]
+# Copy python collection
+COPY --from=BUILDER /root/.local/ /home/avd/.local
 
 # Install Oh My ZSH to provide improved shell
 RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
@@ -57,6 +61,13 @@ RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/inst
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
     && echo 'export TERM=xterm' >>  $HOME/.zshrc
 
+# Set default folder
+WORKDIR /projects
+VOLUME ["/projects"]
+
 # Use ZSH as default shell with default oh-my-zsh theme
-ENV PATH=$PATH:/root/.local/bin
+ENV PATH=$PATH:/home/avd/.local/bin
+USER root
+COPY entrypoint.sh /bin/entrypoint.sh
+RUN chmod +x /bin/entrypoint.sh
 CMD [ "/bin/entrypoint.sh" ]

--- a/3.7/entrypoint.sh
+++ b/3.7/entrypoint.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+DOCKER_SOCKET=/var/run/docker.sock
+DOCKER_GROUP=docker
+USER=avd
 
 # Install specific requirement file
 if [ ! -z "${AVD_REQUIREMENTS}" ]; then
   if [ -f ${AVD_REQUIREMENTS} ]; then
     echo "Install new requirements from ${AVD_REQUIREMENTS}"
-    pip3 install --user -r ${AVD_REQUIREMENTS}
+    sudo -H -u ${USER} pip3 install --upgrade --user -r ${AVD_REQUIREMENTS}
   else
     echo "Requirement file not found, skipping..."
   fi
@@ -14,7 +17,9 @@ fi
 # Install specific ANSIBLE version
 if [ ! -z "${AVD_ANSIBLE}" ]; then
     echo "Install ansible with version ${AVD_ANSIBLE}"
-    pip3 install --user ansible==${AVD_ANSIBLE}
+    # Required for migration from 2.9 to 2.10
+    sudo -H -u ${USER} pip3 uninstall -y ansible
+    sudo -H -u ${USER} pip3 install --upgrade --user ansible==${AVD_ANSIBLE}
 fi
 
 # Reconfigure AVD User id if set by user
@@ -27,6 +32,13 @@ if [ ! -z "${AVD_GID}" ]; then
   echo "Update gid for group avd with ${AVD_GID}"
   groupmod -g ${AVD_GID} avd
 fi
+
+if [ -S ${DOCKER_SOCKET} ]; then
+    sudo chmod 666 /var/run/docker.sock &>/dev/null
+fi
+
+export PATH=$PATH:/home/avd/.local/bin
+export LC_ALL=C.UTF-8
 
 cd /projects/
 su - avd -c "cd /projects && /bin/zsh"

--- a/3.7/entrypoint.sh
+++ b/3.7/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 # Install specific requirement file
 if [ ! -z "${AVD_REQUIREMENTS}" ]; then
   if [ -f ${AVD_REQUIREMENTS} ]; then
@@ -16,4 +17,16 @@ if [ ! -z "${AVD_ANSIBLE}" ]; then
     pip3 install --user ansible==${AVD_ANSIBLE}
 fi
 
-exec /bin/zsh
+# Reconfigure AVD User id if set by user
+if [ ! -z "${AVD_UID}" ]; then
+  echo "Update uid for user avd with ${AVD_UID}"
+  usermod -u ${AVD_UID} avd
+fi
+
+if [ ! -z "${AVD_GID}" ]; then
+  echo "Update gid for group avd with ${AVD_GID}"
+  groupmod -g ${AVD_GID} avd
+fi
+
+cd /projects/
+su - avd -c "cd /projects && /bin/zsh"

--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -53,20 +53,21 @@ RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
 USER avd
 
 # Copy python collection
-COPY --from=BUILDER /root/.local/ /home/avd/.local
+COPY --from=BUILDER /home/avd/.local/ /home/avd/.local
+ENV PATH=$PATH:/home/avd/.local/bin
 
 # Install Oh My ZSH to provide improved shell
 RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
     && echo 'plugins=(ansible common-aliases safe-paste git jsontools history git-extras)' >> $HOME/.zshrc \
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
-    && echo 'export TERM=xterm' >>  $HOME/.zshrc
+    && echo 'export TERM=xterm' >>  $HOME/.zshrc \
+    && echo 'export PATH=$PATH:/home/avd/.local/bin' >> $HOME/.zshrc
 
 # Set default folder
 WORKDIR /projects
 VOLUME ["/projects"]
 
 # Use ZSH as default shell with default oh-my-zsh theme
-ENV PATH=$PATH:/home/avd/.local/bin
 USER root
 COPY entrypoint.sh /bin/entrypoint.sh
 RUN chmod +x /bin/entrypoint.sh

--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -49,7 +49,12 @@ RUN apt-get update \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
+RUN curl -fsSL https://get.docker.com | sh
 RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+RUN usermod -aG docker avd\
+    && usermod -aG sudo avd \
+    && echo "avd ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
 USER avd
 
 # Copy python collection
@@ -61,6 +66,8 @@ RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/inst
     && echo 'plugins=(ansible common-aliases safe-paste git jsontools history git-extras)' >> $HOME/.zshrc \
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
     && echo 'export TERM=xterm' >>  $HOME/.zshrc \
+    && echo "export LC_ALL=C.UTF-8" >> $HOME/.zshrc \
+    && echo "export LANG=C.UTF-8" >> $HOME/.zshrc \
     && echo 'export PATH=$PATH:/home/avd/.local/bin' >> $HOME/.zshrc
 
 # Set default folder

--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -1,10 +1,15 @@
 FROM python:3.8-slim as BUILDER
 
+WORKDIR /tmp
+
 # FROM python:3.7-slim AS compile-image
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential gcc wget git
 
-ENV PATH=/root/.local/bin:$PATH
+RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+USER avd
+
+ENV PATH=$PATH:/home/avd/.local/bin
 RUN pip3 install --upgrade pip
 RUN wget --quiet https://raw.githubusercontent.com/aristanetworks/ansible-avd/devel/development/requirements.txt
 RUN pip3 install --user  -r requirements.txt
@@ -25,6 +30,7 @@ LABEL com.example.version.is-production="False"
 ARG TERM=xterm
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV PROJECT_DIR /projects/
 
 # Install dependencies.
 RUN apt-get update \
@@ -43,13 +49,11 @@ RUN apt-get update \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
-COPY --from=BUILDER /root/.local/ /root/.local
-COPY entrypoint.sh /bin/entrypoint.sh
-RUN chmod +x /bin/entrypoint.sh
+RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+USER avd
 
-# Create the /project directory and add it as a mountpoint
-WORKDIR /projects
-VOLUME ["/projects"]
+# Copy python collection
+COPY --from=BUILDER /root/.local/ /home/avd/.local
 
 # Install Oh My ZSH to provide improved shell
 RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
@@ -57,6 +61,13 @@ RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/inst
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
     && echo 'export TERM=xterm' >>  $HOME/.zshrc
 
+# Set default folder
+WORKDIR /projects
+VOLUME ["/projects"]
+
 # Use ZSH as default shell with default oh-my-zsh theme
-ENV PATH=$PATH:/root/.local/bin
+ENV PATH=$PATH:/home/avd/.local/bin
+USER root
+COPY entrypoint.sh /bin/entrypoint.sh
+RUN chmod +x /bin/entrypoint.sh
 CMD [ "/bin/entrypoint.sh" ]

--- a/3.8/entrypoint.sh
+++ b/3.8/entrypoint.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+DOCKER_SOCKET=/var/run/docker.sock
+DOCKER_GROUP=docker
+USER=avd
 
 # Install specific requirement file
 if [ ! -z "${AVD_REQUIREMENTS}" ]; then
   if [ -f ${AVD_REQUIREMENTS} ]; then
     echo "Install new requirements from ${AVD_REQUIREMENTS}"
-    pip3 install --user -r ${AVD_REQUIREMENTS}
+    sudo -H -u ${USER} pip3 install --upgrade --user -r ${AVD_REQUIREMENTS}
   else
     echo "Requirement file not found, skipping..."
   fi
@@ -14,7 +17,9 @@ fi
 # Install specific ANSIBLE version
 if [ ! -z "${AVD_ANSIBLE}" ]; then
     echo "Install ansible with version ${AVD_ANSIBLE}"
-    pip3 install --user ansible==${AVD_ANSIBLE}
+    # Required for migration from 2.9 to 2.10
+    sudo -H -u ${USER} pip3 uninstall -y ansible
+    sudo -H -u ${USER} pip3 install --upgrade --user ansible==${AVD_ANSIBLE}
 fi
 
 # Reconfigure AVD User id if set by user
@@ -27,6 +32,13 @@ if [ ! -z "${AVD_GID}" ]; then
   echo "Update gid for group avd with ${AVD_GID}"
   groupmod -g ${AVD_GID} avd
 fi
+
+if [ -S ${DOCKER_SOCKET} ]; then
+    sudo chmod 666 /var/run/docker.sock &>/dev/null
+fi
+
+export PATH=$PATH:/home/avd/.local/bin
+export LC_ALL=C.UTF-8
 
 cd /projects/
 su - avd -c "cd /projects && /bin/zsh"

--- a/3.8/entrypoint.sh
+++ b/3.8/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 # Install specific requirement file
 if [ ! -z "${AVD_REQUIREMENTS}" ]; then
   if [ -f ${AVD_REQUIREMENTS} ]; then
@@ -16,4 +17,16 @@ if [ ! -z "${AVD_ANSIBLE}" ]; then
     pip3 install --user ansible==${AVD_ANSIBLE}
 fi
 
-exec /bin/zsh
+# Reconfigure AVD User id if set by user
+if [ ! -z "${AVD_UID}" ]; then
+  echo "Update uid for user avd with ${AVD_UID}"
+  usermod -u ${AVD_UID} avd
+fi
+
+if [ ! -z "${AVD_GID}" ]; then
+  echo "Update gid for group avd with ${AVD_GID}"
+  groupmod -g ${AVD_GID} avd
+fi
+
+cd /projects/
+su - avd -c "cd /projects && /bin/zsh"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ ANSIBLE_VERSION ?=
 PIP_REQ ?= NONE
 # New Flavor creation
 TEMPLATE ?= _template
-
+UID ?= 1000
+GID ?= 1000
 
 .PHONY: help
 help: ## Display help message
@@ -27,11 +28,15 @@ run: ## run docker image
 		docker run --rm -it -v $(CURRENT_DIR)/:/projects \
 			-e AVD_REQUIREMENTS=$(PIP_REQ) \
 			-e AVD_ANSIBLE=$(ANSIBLE_VERSION) \
+			-e AVD_UID=$(UID) \
+			-e AVD_GID=$(GID) \
 			-v /etc/hosts:/etc/hosts $(DOCKER_NAME):$(FLAVOR) ;\
 	else \
 		docker run --rm -it -v $(CURRENT_DIR)/:/projects \
 			-e AVD_REQUIREMENTS=$(PIP_REQ) \
 			-e AVD_ANSIBLE=$(ANSIBLE_VERSION) \
+			-e AVD_UID=$(UID) \
+			-e AVD_GID=$(GID) \
 			-v /etc/hosts:/etc/hosts $(DOCKER_NAME):$(FLAVOR)-$(BRANCH) ;\
 	fi
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ __Table of content__
 
 ### Available Tags
 
-- [`3.6`](3.6/Dockerfile)
+- [`3.6`](3.6/Dockerfile)*
 - [`3.7`](3.7/Dockerfile)
 - [`3.8`](3.8/Dockerfile) / (latest)
 - [`centos-7`](centos-7/Dockerfile) (deprecated)
 - [`centos-8`](centos-8/Dockerfile) (deprecated)
+``
+
+Current image used in AVD development: `avdteam/base:3.6`
 
 ### Available variables
 
@@ -38,8 +41,10 @@ These variables are used in `CMD` to customize container content using [`-e` opt
 
 - `AVD_REQUIREMENTS`: Path to a `requirements.txt` to install during container startup.
 - `AVD_ANSIBLE`: Ansible version to install in container when booting up
+- `AVD_UID`: set __uid__ for avd user in container.
+- `AVD_GID`: set __gid__ for avd user in container.
 
-To see how to customize your container with this option, you can refer to [How to install ansible and Python requirements page](docs/run-options.md)
+To see how to customize your container with these options, you can refer to [How to install ansible and Python requirements page](docs/run-options.md)
 
 ## How to leverage image
 

--- a/_template/Dockerfile
+++ b/_template/Dockerfile
@@ -1,16 +1,20 @@
 FROM python:FLAVOR-slim as BUILDER
 
+WORKDIR /tmp
+
 # FROM python:3.7-slim AS compile-image
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential gcc wget git
 
-ENV PATH=/root/.local/bin:$PATH
+RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+USER avd
+
+ENV PATH=$PATH:/home/avd/.local/bin
 RUN pip3 install --upgrade pip
 RUN wget --quiet https://raw.githubusercontent.com/aristanetworks/ansible-avd/devel/development/requirements.txt
 RUN pip3 install --user  -r requirements.txt
 RUN wget --quiet https://raw.githubusercontent.com/aristanetworks/ansible-avd/devel/development/requirements-dev.txt
 RUN pip3 install --user  -r requirements-dev.txt
-
 
 FROM python:FLAVOR-slim as BASE
 
@@ -25,6 +29,7 @@ LABEL com.example.version.is-production="False"
 ARG TERM=xterm
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV PROJECT_DIR /projects/
 
 # Install dependencies.
 RUN apt-get update \
@@ -43,13 +48,11 @@ RUN apt-get update \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
-COPY --from=BUILDER /root/.local/ /root/.local
-COPY entrypoint.sh /bin/entrypoint.sh
-RUN chmod +x /bin/entrypoint.sh
+RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+USER avd
 
-# Create the /project directory and add it as a mountpoint
-WORKDIR /projects
-VOLUME ["/projects"]
+# Copy python collection
+COPY --from=BUILDER /root/.local/ /home/avd/.local
 
 # Install Oh My ZSH to provide improved shell
 RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
@@ -57,6 +60,13 @@ RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/inst
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
     && echo 'export TERM=xterm' >>  $HOME/.zshrc
 
+# Set default folder
+WORKDIR /projects
+VOLUME ["/projects"]
+
 # Use ZSH as default shell with default oh-my-zsh theme
-ENV PATH=$PATH:/root/.local/bin
+ENV PATH=$PATH:/home/avd/.local/bin
+USER root
+COPY entrypoint.sh /bin/entrypoint.sh
+RUN chmod +x /bin/entrypoint.sh
 CMD [ "/bin/entrypoint.sh" ]

--- a/_template/Dockerfile
+++ b/_template/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:FLAVOR-slim as BUILDER
+FROM python:{{PYTHON_VERSION}}-slim as BUILDER
 
 WORKDIR /tmp
 
@@ -16,7 +16,8 @@ RUN pip3 install --user  -r requirements.txt
 RUN wget --quiet https://raw.githubusercontent.com/aristanetworks/ansible-avd/devel/development/requirements-dev.txt
 RUN pip3 install --user  -r requirements-dev.txt
 
-FROM python:FLAVOR-slim as BASE
+
+FROM python:{{PYTHON_VERSION}}-slim as BASE
 
 LABEL maintainer="Arista Ansible Team <ansible@arista.com>"
 LABEL com.example.version="1.0.2"
@@ -44,28 +45,39 @@ RUN apt-get update \
     sshpass \
     git-extras \
     openssh-client \
+    sudo \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
+RUN curl -fsSL https://get.docker.com | sh
 RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
+RUN usermod -aG docker avd\
+    && usermod -aG sudo avd \
+    && echo "avd ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
 USER avd
 
 # Copy python collection
-COPY --from=BUILDER /root/.local/ /home/avd/.local
+COPY --from=BUILDER /home/avd/.local/ /home/avd/.local
+ENV PATH=$PATH:/home/avd/.local/bin
 
 # Install Oh My ZSH to provide improved shell
 RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
     && echo 'plugins=(ansible common-aliases safe-paste git jsontools history git-extras)' >> $HOME/.zshrc \
     && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
-    && echo 'export TERM=xterm' >>  $HOME/.zshrc
+    && echo 'export TERM=xterm' >>  $HOME/.zshrc \
+    && echo "export LC_ALL=C.UTF-8" >> $HOME/.zshrc \
+    && echo "export LANG=C.UTF-8" >> $HOME/.zshrc \
+    && echo "export LC_ALL=C.UTF-8" >> $HOME/.zshrc \
+    && echo "export LANG=C.UTF-8" >> $HOME/.zshrc \
+    && echo 'export PATH=$PATH:/home/avd/.local/bin' >> $HOME/.zshrc
 
 # Set default folder
 WORKDIR /projects
 VOLUME ["/projects"]
 
 # Use ZSH as default shell with default oh-my-zsh theme
-ENV PATH=$PATH:/home/avd/.local/bin
 USER root
 COPY entrypoint.sh /bin/entrypoint.sh
 RUN chmod +x /bin/entrypoint.sh

--- a/_template/entrypoint.sh
+++ b/_template/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 # Install specific requirement file
 if [ ! -z "${AVD_REQUIREMENTS}" ]; then
   if [ -f ${AVD_REQUIREMENTS} ]; then
@@ -16,4 +17,16 @@ if [ ! -z "${AVD_ANSIBLE}" ]; then
     pip3 install --user ansible==${AVD_ANSIBLE}
 fi
 
-exec /bin/zsh
+# Reconfigure AVD User id if set by user
+if [ ! -z "${AVD_UID}" ]; then
+  echo "Update uid for user avd with ${AVD_UID}"
+  usermod -u ${AVD_UID} avd
+fi
+
+if [ ! -z "${AVD_GID}" ]; then
+  echo "Update gid for group avd with ${AVD_GID}"
+  groupmod -g ${AVD_GID} avd
+fi
+
+cd /projects/
+su - avd -c "cd /projects && /bin/zsh"


### PR DESCRIPTION
Fixes #9 

## Issue summary

Since Docker is using different methods to share files between host and container, it may be required to set `UID` and `GID` of ZSH when you need to update files from your containers.

https://www.reddit.com/r/docker/comments/jh9qyt/inconsistent_behaviour_with_permissions_of_a_bind/

## Summary

Idea is to create a user named `avd` with preconfigure shell and `uid=1000` / `gid=1000`. 

```Dockerfile
[...]
RUN useradd -md /home/avd -s /bin/zsh -u 1000 avd
USER avd

# Install Oh My ZSH to provide improved shell
RUN wget --quiet https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
    && echo 'plugins=(ansible common-aliases safe-paste git jsontools history git-extras)' >> $HOME/.zshrc \
    && echo 'eval `ssh-agent -s`' >> $HOME/.zshrc \
    && echo 'export TERM=xterm' >>  $HOME/.zshrc

# Set default folder
WORKDIR /projects
VOLUME ["/projects"]

# Use ZSH as default shell with default oh-my-zsh theme
ENV PATH=$PATH:/root/.local/bin
USER root
CMD [ "/bin/entrypoint.sh" ]
```

Entrypoint will implement support for custom value:

```bash
# Reconfigure AVD User id if set by user
if [ ! -z "${AVD_UID}" ]; then
  echo "Update uid for user avd with ${AVD_UID}"
  usermod -u ${AVD_UID} avd
fi

if [ ! -z "${AVD_GID}" ]; then
  echo "Update gid for group avd with ${AVD_GID}"
  groupmod -g ${AVD_GID} avd
fi

su - avd -c /bin/zsh
```

## Usage

```bash
❯ id
uid=501(titom73) gid=20(staff)

❯ docker run --rm -it -v ./docker-avd-base/:/projects \
	-e AVD_REQUIREMENTS=NONE \
	-e AVD_ANSIBLE= \
	-e AVD_UID=1001 \
	-e AVD_GID=1001 \
	-v /etc/hosts:/etc/hosts avdteam/base:3.6-feature-uid

Requirement file not found, skipping...
Update uid for user avd with 1001
Update gid for group avd with 1001
Agent pid 53
➜  /projects git:(feature-uid) id
uid=1001(avd) gid=1001(avd) groups=1001(avd)
```
