### PR TITLE
Make: Add GH actions to build docker image

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -1,0 +1,44 @@
+---
+  name: docker-builder-edge
+  on:
+    push:
+      branches:
+        - 'master'
+
+  jobs:
+    docker:
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: true
+        matrix:
+          python_version:
+            - 3.8
+            - 3.6
+            - 3.9
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Docker meta for EDGE
+          id: meta
+          uses: docker/metadata-action@v3
+          if: startsWith(github.ref, 'refs/heads/master')
+          with:
+            images: ${{ secrets.DOCKER_IMAGE }}
+            tags: |
+              type=edge,prefix=${{matrix.python_version}}-
+
+        - name: Login to DockerHub
+          uses: docker/login-action@v1
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+        - name: Build and push
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            file: ${{ matrix.python_version }}/Dockerfile
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,0 +1,44 @@
+---
+  name: docker-builder-pull-requests
+  on:
+    pull_request_target:
+      branches:
+        - 'master'
+
+  jobs:
+    docker:
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: true
+        matrix:
+          python_version:
+            - 3.8
+            - 3.6
+            - 3.9
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Docker meta for PR
+          id: meta
+          uses: docker/metadata-action@v3
+          if: github.event_name == 'pull_request'
+          with:
+            images: ${{ secrets.DOCKER_IMAGE }}
+            tags: |
+              type=ref,enable=true,priority=600,prefix=${{matrix.python_version}}-pr-,suffix=,event=pr
+
+        - name: Login to DockerHub
+          uses: docker/login-action@v1
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+        - name: Build and push
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            file: ${{ matrix.python_version }}/Dockerfile
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -1,0 +1,43 @@
+---
+  name: docker-builder-tags
+  on:
+    push:
+      tags:
+        - 'v*'
+
+  jobs:
+    docker:
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: true
+        matrix:
+          python_version:
+            - 3.8
+            - 3.6
+            - 3.9
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Docker meta for TAG
+          id: meta
+          uses: docker/metadata-action@v3
+          with:
+            images: ${{ secrets.DOCKER_IMAGE }}
+            tags: |
+              type=match,pattern=v(.*),group=1, enable=true,priority=600,prefix=${{matrix.python_version}}-v,suffix=,value=
+
+        - name: Login to DockerHub
+          uses: docker/login-action@v1
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+        - name: Build and push
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            file: ${{ matrix.python_version }}/Dockerfile
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Move build process to github action since it is not available anymore in Docker Hub.

__Requirements__

- Username and Password set in secret
- Docker image set in secret

__Workflows__

- Build a container for each PR for python `3.6`, `3.8` and `3.9`: `image:{{pythonVersion}}-pr-{{prId}}`
- Build a container for every push in master: `image:{{pythonVersion}}-edge`
- Build a docker image per tag: `image:{{pythonVersion}}-v{{tag-id}}`

__Next step__

- deprecate multiple flavors of python


[Test image based on current CI](https://hub.docker.com/repository/docker/titom73/test)

