### PR TITLE
Multi-Arch Container Builds:

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -42,6 +42,7 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
+            platforms: linux/amd64, linux/arm64/v8, linux/arm/v7
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -38,6 +38,7 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
+            platforms: linux/amd64, linux/arm64/v8, linux/arm/v7
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -50,6 +50,7 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
+            platforms: linux/amd64, linux/arm64/v8, linux/arm/v7
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds the platform parameter to the github action workflows to build against different architectures,

Platforms targeted are:
- linux/amd64
- linux/arm64/v8
- linux/arm/v7