### PR TITLE
Revert "Multi-Arch Container Builds:"

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -42,7 +42,6 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
-            platforms: linux/amd64, linux/arm64/v8, linux/arm/v7
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -38,7 +38,6 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
-            platforms: linux/amd64, linux/arm64/v8, linux/arm/v7
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -50,7 +50,6 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
-            platforms: linux/amd64, linux/arm64/v8, linux/arm/v7
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Reverts arista-netdevops-community/docker-avd-base#27

Need to investigate additional action to support building with multiple platforms:

```
Error: buildx failed with: error: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
```
 
Look at GitHub action: https://github.com/docker/build-push-action
