### PR TITLE
Mutli-Arch Builds

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -22,6 +22,15 @@
         - name: Checkout
           uses: actions/checkout@v2
 
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v2
+          with:
+            platforms: amd64,arm64
+
+        - name: Set up Docker Buildx
+          id: buildx
+          uses: docker/setup-buildx-action@v2
+
         - name: Docker meta for EDGE
           id: meta
           uses: docker/metadata-action@v3
@@ -42,6 +51,7 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
+            platforms: linux/amd64, linux/arm64
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -19,6 +19,15 @@
         - name: Checkout
           uses: actions/checkout@v2
 
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v2
+          with:
+            platforms: amd64,arm64
+
+        - name: Set up Docker Buildx
+          id: buildx
+          uses: docker/setup-buildx-action@v2
+
         - name: Docker meta for PR
           id: meta
           uses: docker/metadata-action@v3
@@ -38,6 +47,7 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
+            platforms: linux/amd64, linux/arm64
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -24,6 +24,15 @@
           with:
             fetch-depth: 0
 
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v2
+          with:
+            platforms: amd64,arm64
+
+        - name: Set up Docker Buildx
+          id: buildx
+          uses: docker/setup-buildx-action@v2
+
         - name: Collect latest git TAG for refresh
           id: get_latest_tag
           run: |
@@ -50,6 +59,7 @@
           with:
             context: .
             file: ${{ matrix.python_version }}/Dockerfile
+            platforms: linux/amd64, linux/arm64
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Updated Github action workflows to create amd64 and arm64 based builds.

Steps added to this change are:
- Setting up Qemu 
- Setting up Docker Bulidx
- Specifying target platforms
Fixes #26 